### PR TITLE
Prevent climbing too soon.

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -376,6 +376,7 @@ public class Robot extends TimedRobot {
       m_autonomousCommand.cancel();
     }
     m_coral.resetElevator();
+    m_climber.resetClimb();
 
     if (!DriverStation.getAlliance().isEmpty()) {
       var alliance = DriverStation.getAlliance().get();

--- a/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
@@ -17,6 +17,9 @@ public class ClimberSubsystem extends SubsystemBase {
   private final SparkMax m_max = new SparkMax(ClimberConstants.kClimberCanId, MotorType.kBrushless);
   private final SparkAbsoluteEncoder m_encoder = m_max.getAbsoluteEncoder();
 
+  private boolean canClimb = false;
+  private boolean climbed = false;
+
   public ClimberSubsystem() {
     m_max.configure(
         Configs.ClimberConfigs.climberConfig,
@@ -68,8 +71,11 @@ public class ClimberSubsystem extends SubsystemBase {
     var position = getPosition();
     if (position < ClimberConstants.kClimbMin) {
       m_max.set(0);
-    } else {
+      climbed = true;
+    } else if (canClimb) {
       m_max.set(-1);
+    } else {
+      m_max.set(0);
     }
   }
 
@@ -78,11 +84,24 @@ public class ClimberSubsystem extends SubsystemBase {
   }
 
   public Command deployCommand() {
-    return run(() -> deploy()).until(() -> getPosition() >= ClimberConstants.kMaxLimit);
+    return run(() -> deploy()).until(() -> getPosition() >= ClimberConstants.kMaxLimit).andThen(() -> {canClimb = true;});
   }
 
   public Command climbCommand() {
     return run(() -> climb());
+  }
+
+  public void resetClimb() {
+    canClimb = false;
+    climbed = false;
+  }
+
+  public boolean getCanClimb() {
+    return canClimb;
+  }
+
+  public boolean getClimbed() {
+    return climbed;
   }
 
   public Command stopCommand() {

--- a/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
@@ -84,7 +84,12 @@ public class ClimberSubsystem extends SubsystemBase {
   }
 
   public Command deployCommand() {
-    return run(() -> deploy()).until(() -> getPosition() >= ClimberConstants.kMaxLimit).andThen(() -> {canClimb = true;});
+    return run(() -> deploy())
+        .until(() -> getPosition() >= ClimberConstants.kMaxLimit)
+        .andThen(
+            () -> {
+              canClimb = true;
+            });
   }
 
   public Command climbCommand() {


### PR DESCRIPTION
Make it so that we can't climb until the arm is fully deployed so that we won't damage the robot.