### PR TITLE
Enable Driver Station Logging

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -104,6 +104,7 @@ public class Robot extends TimedRobot {
     m_lastTime = Timer.getFPGATimestamp();
 
     DataLogManager.start();
+    DriverStation.startDataLog(DataLogManager.getLog());
     Epilogue.bind(this);
   }
 


### PR DESCRIPTION
This makes sure that the DriverStation information is being logged. It will include logs of the joysticks.